### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,8 @@ on:
 
 jobs:
   build:
+    permissions:
+      contents: read
     runs-on: windows-latest
     strategy:
       matrix:
@@ -55,6 +57,8 @@ jobs:
           path: RemoteLogViewer-${{ github.ref_name }}-${{ matrix.runtime }}.zip
 
   release:
+    permissions:
+      contents: write
     runs-on: ubuntu-latest
     needs: build
     steps:


### PR DESCRIPTION
Potential fix for [https://github.com/xm-i/RemoteLogViewer/security/code-scanning/1](https://github.com/xm-i/RemoteLogViewer/security/code-scanning/1)

The best and safest way to fix this issue is to explicitly declare the `permissions` block at the job level for each job in the workflow, tailored to the needs of each job. In this particular workflow:
- The `build` job only checks out code, uses artifacts, and builds/upload packages. It does not change repository contents.
- The `release` job creates a GitHub release, which requires `contents: write`.

So:  
- Add `permissions: contents: read` to the `build` job.
- Add `permissions: contents: write` to the `release` job.

No additional imports or dependencies are needed. Edit the `.github/workflows/release.yml` file at the start of each job definition (`build:` and `release:`) and insert the appropriate `permissions` block.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
