### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build-web-assets.yml
+++ b/.github/workflows/build-web-assets.yml
@@ -1,4 +1,6 @@
 name: Build Web Assets (Debug)
+permissions:
+  contents: read
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
Potential fix for [https://github.com/xm-i/RemoteLogViewer/security/code-scanning/4](https://github.com/xm-i/RemoteLogViewer/security/code-scanning/4)

To fix the problem, add a `permissions` block to the workflow file, specifying the minimal set of permissions required for the workflow. The best way to address this is to add `permissions: contents: read` at the root of the workflow, just below the `name` and above the `on` block (line 2 or 3). This will ensure only read access to the repository contents is granted by default, adhering to the principle of least privilege and reducing the risk of accidental or malicious repository modification. No other permissions are demonstrably needed for the tasks executed in this workflow.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
