### PR TITLE
Fix failing tests and related off-by-one errors

### DIFF
--- a/RemoteLogViewer.Core.Tests/Models/Ssh/FileViewer/Operation/BuildByteOffsetMapOperationTests.cs
+++ b/RemoteLogViewer.Core.Tests/Models/Ssh/FileViewer/Operation/BuildByteOffsetMapOperationTests.cs
@@ -18,7 +18,7 @@ public class BuildByteOffsetMapOperationTests {
 		var subject = new Subject<ByteOffset>();
 
 		var sshMock = new Mock<ISshService>();
-		sshMock.Setup(s => s.CreateByteOffsetMap("file.log", 100, null, It.IsAny<CancellationToken>())).Returns((string _, int _, CancellationToken t) => subject.ToAsyncEnumerable(t));
+		sshMock.Setup(s => s.CreateByteOffsetMap("file.log", 100, null, It.IsAny<CancellationToken>())).Returns((string _, int _, ByteOffset? _, CancellationToken t) => subject.ToAsyncEnumerable(t));
 
 		using var opRegistry = new OperationRegistry();
 		var loggerMock = new Mock<ILogger<BuildByteOffsetMapOperation>>();
@@ -93,7 +93,7 @@ public class BuildByteOffsetMapOperationTests {
 		var subject = new Subject<ByteOffset>();
 
 		var sshMock = new Mock<ISshService>();
-		sshMock.Setup(s => s.CreateByteOffsetMap("file.log", 100, null, It.IsAny<CancellationToken>())).Returns((string _, int _, CancellationToken t) => subject.ToAsyncEnumerable(t));
+		sshMock.Setup(s => s.CreateByteOffsetMap("file.log", 100, null, It.IsAny<CancellationToken>())).Returns((string _, int _, ByteOffset? _, CancellationToken t) => subject.ToAsyncEnumerable(t));
 
 		using var opRegistry = new OperationRegistry();
 		var loggerMock = new Mock<ILogger<BuildByteOffsetMapOperation>>();

--- a/RemoteLogViewer.Core.Tests/Models/Ssh/FileViewer/Operation/GrepOperationTests.cs
+++ b/RemoteLogViewer.Core.Tests/Models/Ssh/FileViewer/Operation/GrepOperationTests.cs
@@ -21,7 +21,7 @@ public class GrepOperationTests {
 		var subject = new Subject<TextLine>();
 		var sshMock = new Mock<ISshService>();
 		sshMock.Setup(s => s.GrepAsync("file.log", "ERR", null, 100, It.IsAny<ByteOffset>(), 1, false, false, It.IsAny<CancellationToken>()))
-			.Returns((string _, string _, bool _, string? _, int _, ByteOffset bo, long _, CancellationToken t) => subject.ToAsyncEnumerable(t));
+			.Returns((string _, string _, string? _, int _, ByteOffset bo, long _, bool _, bool _, CancellationToken t) => subject.ToAsyncEnumerable(t));
 
 		using var opRegistry = new OperationRegistry();
 		var loggerMock = new Mock<ILogger<GrepOperation>>();
@@ -64,7 +64,7 @@ public class GrepOperationTests {
 		var subject = new Subject<TextLine>();
 		var sshMock = new Mock<ISshService>();
 		sshMock.Setup(s => s.GrepAsync("file.log", "ERR", null, 100, It.IsAny<ByteOffset>(), 1, false, false, It.IsAny<CancellationToken>()))
-			.Returns((string _, string _, bool _, string? _, int _, ByteOffset bo, long _, CancellationToken t) => subject.ToAsyncEnumerable(t));
+			.Returns((string _, string _, string? _, int _, ByteOffset bo, long _, bool _, bool _, CancellationToken t) => subject.ToAsyncEnumerable(t));
 
 		using var opRegistry = new OperationRegistry();
 		var loggerMock = new Mock<ILogger<GrepOperation>>();

--- a/RemoteLogViewer.Core/Models/Ssh/FileViewer/ByteOffsetMap/ByteOffsetIndex.cs
+++ b/RemoteLogViewer.Core/Models/Ssh/FileViewer/ByteOffsetMap/ByteOffsetIndex.cs
@@ -26,7 +26,7 @@ public class ByteOffsetIndex : IByteOffsetIndex {
 	}
 
 	public ByteOffset Find(long targetLine) {
-		ByteOffset result = new(1, 1);
+		ByteOffset result = new(0, 0);
 		foreach (var bo in this._entries) {
 			if (bo.LineNumber < targetLine) {
 				result = bo;

--- a/RemoteLogViewer.Core/Models/Ssh/FileViewer/Operation/BuildByteOffsetMapOperation.cs
+++ b/RemoteLogViewer.Core/Models/Ssh/FileViewer/Operation/BuildByteOffsetMapOperation.cs
@@ -54,7 +54,7 @@ public sealed class BuildByteOffsetMapOperation : ModelBase<BuildByteOffsetMapOp
 		try {
 			var offsets = sshService.CreateByteOffsetMap(filePath, chunkSize, startByteOffset, op.Token);
 			await foreach (var entry in offsets.WithCancellation(op.Token)) {
-				this._processedBytes.Value = entry.Bytes - 1;
+				this._processedBytes.Value = entry.Bytes;
 				yield return entry;
 				if (op.Token.IsCancellationRequested) {
 					yield break;


### PR DESCRIPTION
- Corrected Moq Setup arguments in BuildByteOffsetMapOperationTests and GrepOperationTests to match interface signatures.
- Fixed an off-by-one error when processing bytes in BuildByteOffsetMapOperation.
- Changed default ByteOffset base from new(1,1) to new(0,0) in ByteOffsetIndex to align with expected index behavior.

---
*PR created automatically by Jules for task [12437598378201001271](https://jules.google.com/task/12437598378201001271) started by @xm-i*