### PR TITLE
🧹 [code health improvement] Remove empty catch block in tests

### DIFF
--- a/RemoteLogViewer.Core.Tests/Models/Ssh/FileViewer/Operation/SaveRangeContentOperationTests.cs
+++ b/RemoteLogViewer.Core.Tests/Models/Ssh/FileViewer/Operation/SaveRangeContentOperationTests.cs
@@ -69,14 +69,12 @@ public class SaveRangeContentOperationTests {
 		using var writer = new StreamWriter(ms, new System.Text.UTF8Encoding(encoderShouldEmitUTF8Identifier: false), leaveOpen: true);
 		var task = op.ExecuteAsync(sshMock.Object, "file.log", writer, 1, 5, null, cts.Token);
 
-		try {
-			subject.OnNext(new TextLine(1, "A"));
-			subject.OnNext(new TextLine(2, "B"));
-			subject.OnNext(new TextLine(3, "C"));
-			await WaitUntilAsync(() => op.SavedLines.CurrentValue, 3);
-			cts.Cancel();
-			await task;
-		} catch (OperationCanceledException) { }
+		subject.OnNext(new TextLine(1, "A"));
+		subject.OnNext(new TextLine(2, "B"));
+		subject.OnNext(new TextLine(3, "C"));
+		await WaitUntilAsync(() => op.SavedLines.CurrentValue, 3);
+		cts.Cancel();
+		await task.ShouldThrowAsync<OperationCanceledException>();
 		await writer.FlushAsync();
 		var text = System.Text.Encoding.UTF8.GetString(ms.ToArray()).TrimEnd();
 


### PR DESCRIPTION
### 🎯 **What:**
The code health issue addressed is an empty `catch (OperationCanceledException) { }` block in `SaveRangeContentOperationTests.cs`.

### 💡 **Why:**
Using an empty catch block in tests masks the actual outcome and reduces the expressiveness of the test. Replacing it with `await task.ShouldThrowAsync<OperationCanceledException>();` explicitly asserts that the cancellation happened as expected, improving maintainability and readability.

### ✅ **Verification:**
- Confirmed that the codebase uses the **Shouldly** assertion library.
- Verified that `OperationCanceledException` is indeed expected when `cts.Cancel()` is called before awaiting the task in `ExecuteAsync_Cancel_ShouldStopEarly`.
- Attempted to run the specific test using `dotnet test`, though the command timed out in the current environment, the change is a standard and safe refactoring in .NET testing.

### ✨ **Result:**
The test code is now cleaner and follows better testing practices by using explicit assertions for expected exceptions.

---
*PR created automatically by Jules for task [495810483704442861](https://jules.google.com/task/495810483704442861) started by @xm-i*