### PR TITLE
⚡ [performance] HighlightService における不必要な配列割り当ての排除

### DIFF
--- a/RemoteLogViewer.Core/Services/Viewer/HighlightService.cs
+++ b/RemoteLogViewer.Core/Services/Viewer/HighlightService.cs
@@ -140,7 +140,7 @@ public class HighlightService {
 		var endsLookup = mergedWordStyles.ToLookup(x => x.End + 1);
 
 		// スタイルの付け替えが発生する可能性のあるindexを列挙
-		foreach (var index in mergedWordStyles.SelectMany(x => new int[] { x.Start, x.End + 1 }).OrderBy(x => x).Distinct()) {
+		foreach (var index in mergedWordStyles.Select(x => x.Start).Concat(mergedWordStyles.Select(x => x.End + 1)).OrderBy(x => x).Distinct()) {
 			_ = sb.Append(Escape(content[(styledIndex + 1)..index]));
 			styledIndex = index - 1;
 


### PR DESCRIPTION
`HighlightService.CreateStyledLine` メソッドにおいて、ハイライトが必要なインデックスを抽出する際の `SelectMany` 内での不必要な配列割り当てを修正しました。

具体的には、
`mergedWordStyles.SelectMany(x => new int[] { x.Start, x.End + 1 })` 
というコードを、
`mergedWordStyles.Select(x => x.Start).Concat(mergedWordStyles.Select(x => x.End + 1))` 
に変更しました。

これにより、各 `mergedWordStyles` 要素に対して新しい配列オブジェクトが生成されるのを回避し、ガベージコレクション（GC）の負荷を軽減しました。

環境の制約（ビルドおよびテストのタイムアウト）により、実際のパフォーマンス計測結果を提供することはできませんでしたが、この変更は論理的に等価であり、かつ一般的な .NET における LINQ のメモリ最適化手法に基づいています。


---
*PR created automatically by Jules for task [8632216767194280511](https://jules.google.com/task/8632216767194280511) started by @xm-i*